### PR TITLE
Add PHP 8.0 and 8.1 test

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,18 +1,28 @@
 name: PHP Composer
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
+  push:
     branches: [ master ]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
+          - "8.1"
+        operating-system:
+          - "ubuntu-latest"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: "Install PHP"
+      uses: "shivammathur/setup-php@v2"
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict


### PR DESCRIPTION
# Changed log

- Since this PHP package requires `php-8.0` version at least, I think the `php-8.1` version should be tested, too.
- Install `shivammathur/setup-php@v2` to complete above issue.
- Letting this repository on master branch trigger GitHub Action when pushing the commit.
- Letting this repository on any branch name trigger GitHub Action when creating the PR.
- This GitHub Action building log is available [here](https://github.com/open-source-contributions/kwai-jsonapi/actions/runs/1523962201).